### PR TITLE
Delete high scores

### DIFF
--- a/scenes/ScoreScene.tscn
+++ b/scenes/ScoreScene.tscn
@@ -14,7 +14,6 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_njlob")
 highScoreLabel = NodePath("High Score Label")
-nameInput = NodePath("")
 
 [node name="High Score Label" type="Label" parent="."]
 layout_mode = 1

--- a/scenes/ScoreScene.tscn
+++ b/scenes/ScoreScene.tscn
@@ -36,3 +36,11 @@ offset_right = 41.0
 offset_bottom = 34.0
 scale = Vector2(10, 10)
 text = "Back"
+
+[node name="Clear Scores Button" type="Button" parent="."]
+layout_mode = 1
+offset_top = 350.0
+offset_right = 103.0
+offset_bottom = 381.0
+scale = Vector2(10, 10)
+text = "Clear Scores"

--- a/scenes/ScoreScene.tscn
+++ b/scenes/ScoreScene.tscn
@@ -14,7 +14,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_njlob")
 highScoreLabel = NodePath("High Score Label")
-nameInput = NodePath("Name Input")
+nameInput = NodePath("")
 
 [node name="High Score Label" type="Label" parent="."]
 layout_mode = 1
@@ -36,34 +36,3 @@ offset_right = 41.0
 offset_bottom = 34.0
 scale = Vector2(10, 10)
 text = "Back"
-
-[node name="Name Input" type="LineEdit" parent="."]
-layout_mode = 1
-anchors_preset = 7
-anchor_left = 0.5
-anchor_top = 1.0
-anchor_right = 0.5
-anchor_bottom = 1.0
-offset_left = -350.0
-offset_top = -540.0
-offset_right = -282.938
-offset_bottom = -509.0
-grow_horizontal = 2
-grow_vertical = 0
-scale = Vector2(10, 10)
-
-[node name="Save Score Button" type="Button" parent="."]
-layout_mode = 1
-anchors_preset = 7
-anchor_left = 0.5
-anchor_top = 1.0
-anchor_right = 0.5
-anchor_bottom = 1.0
-offset_left = -278.0
-offset_top = -186.0
-offset_right = -168.0
-offset_bottom = -155.0
-grow_horizontal = 2
-grow_vertical = 0
-scale = Vector2(5, 5)
-text = "Save"

--- a/scripts/HighScorePage.cs
+++ b/scripts/HighScorePage.cs
@@ -28,7 +28,8 @@ public partial class HighScorePage : Node
 	{
 	}
 
-	private void clearScoreButtonPressed() {
+	private void clearScoreButtonPressed()
+	{
 		GD.Print("Clear scores button pressed");
 		// Clear the scores from the file
 		ScoreRepository scoreRepository = new ScoreRepository();

--- a/scripts/HighScorePage.cs
+++ b/scripts/HighScorePage.cs
@@ -18,17 +18,22 @@ public partial class HighScorePage : Node
 
 		Button backButton = GetNode<Button>("Back Button");
 		backButton.Pressed += _OnBackButtonPressed;
-		LineEdit nameInput = GetNode<LineEdit>("Name Input");
-		Button saveButton = GetNode<Button>("Save Score Button");
-		saveButton.Pressed += OnSaveButtonPressed;
-
-
+		Button clearScoresButton = GetNode<Button>("Clear Scores Button");
+		clearScoresButton.Pressed += clearScoreButtonPressed;
 		displayHighScores();
 	}
 
 	// Called every frame. 'delta' is the elapsed time since the previous frame.
 	public override void _Process(double delta)
 	{
+	}
+
+	private void clearScoreButtonPressed() {
+		GD.Print("Clear scores button pressed");
+		// Clear the scores from the file
+		ScoreRepository scoreRepository = new ScoreRepository();
+		scoreRepository.ClearScores();
+		displayHighScores();
 	}
 
 	private void _OnBackButtonPressed()

--- a/scripts/ScoreRepository.cs
+++ b/scripts/ScoreRepository.cs
@@ -64,4 +64,19 @@ public class ScoreRepository
 		}
 		return playerScores;
 	}
+
+	public void ClearScores()
+	{
+		GD.Print("Clearing scores...");
+		string savePath = "user://SaveData";
+		try
+		{
+			using Godot.FileAccess file = Godot.FileAccess.Open(savePath, Godot.FileAccess.ModeFlags.Write);
+			file.StoreLine(""); // Clear the file by writing an empty line
+		}
+		catch (Exception e)
+		{
+			GD.PrintErr("Failed to clear scores: " + e.Message);
+		}
+	}
 }

--- a/scripts/ScoreRepository.cs
+++ b/scripts/ScoreRepository.cs
@@ -72,7 +72,7 @@ public class ScoreRepository
 		try
 		{
 			using Godot.FileAccess file = Godot.FileAccess.Open(savePath, Godot.FileAccess.ModeFlags.Write);
-			file.StoreLine(""); // Clear the file by writing an empty line
+			file.StoreString(""); // Clear the file by writing an empty string
 		}
 		catch (Exception e)
 		{


### PR DESCRIPTION
This pull request updates the high score page to add a "Clear Scores" feature and removes the ability for users to input and save their names and scores. The main changes involve updating the UI to replace the name input and save button with a "Clear Scores" button, and implementing the logic to clear saved scores from storage.

**UI changes:**

* Removed the `Name Input` and `Save Score Button` nodes from `ScoreScene.tscn`, and added a new `Clear Scores Button` node with appropriate properties. [[1]](diffhunk://#diff-0cf3b8aeadaebe3eb9371728b2df1187af0a14796f2e7ee384b38c31d808ee76L17-R17) [[2]](diffhunk://#diff-0cf3b8aeadaebe3eb9371728b2df1187af0a14796f2e7ee384b38c31d808ee76L40-R46)

**Feature implementation:**

* In `HighScorePage.cs`, removed logic related to name input and saving scores, and added logic to handle the new clear scores button, including a new event handler that clears scores and refreshes the display. [[1]](diffhunk://#diff-eb79c814684449c7c35b2690ee567a5eeb2baf08b38afae2ba8a9b8d7c05a4fcL21-R22) [[2]](diffhunk://#diff-eb79c814684449c7c35b2690ee567a5eeb2baf08b38afae2ba8a9b8d7c05a4fcR31-R38)
* Added a new `ClearScores` method to `ScoreRepository.cs` to overwrite the score file and effectively clear all saved scores.